### PR TITLE
Fix replay bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 name = "sc2sceneswitcher"
 description = "Program for automatically switching OBS scenes when entering a SC2 game or replay"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
     { name = "Jaedolph - Lord of Games" }
 ]


### PR DESCRIPTION
Code that was used to not check sc2replaystats if the previous game was a replay would also trigger if the streamer quit the game with "quit and rewind" rather than "surrender". Changed the way it is determined if the last game was a replay to fix this.